### PR TITLE
Strip stray ref to postgresql in pg gem output

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,6 +3,22 @@
 , runtimeDirectory ? null
 }:
 
+let pkgs' = pkgs; in # break reference cycle
+let
+
+  pkgs = pkgs'.appendOverlays [(final: super: {
+    defaultGemConfig = super.defaultGemConfig // {
+      pg = attrs: (super.defaultGemConfig.pg attrs) // {
+        # Strip files that keep `final.postgresql` refs in the closure.
+        postInstall = ''
+          find $out/lib/ruby/gems/ -name 'pg-*.info' -delete
+        '';
+      };
+    };
+  })];
+
+in
+
 let
   #
   # `callPackage` is the mechanism used for dependency injection within Nixpkgs.


### PR DESCRIPTION
This should be tracked upstream at Nixpkgs, it seems stripping those
info files may provide us some quick gains in closure sizes.

Fixes #6.