### PR TITLE
Implement strict layering for the images

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -86,6 +86,8 @@ let
       '';
 
       passthru = {
+        inherit ruby;
+        inherit gems;
         inherit (gems) wrappedRuby;
       };
     }

--- a/default.nix
+++ b/default.nix
@@ -20,6 +20,9 @@ let
 in
 
 let
+  # This could be part of the Fly overlay instead.
+  flyImageTools = pkgs.callPackage ./image-tools.nix { };
+
   #
   # `callPackage` is the mechanism used for dependency injection within Nixpkgs.
   # It takes two parameters:
@@ -103,43 +106,36 @@ let
   };
 
   dockerImage = pkgs.callPackage (
-
     { lib
-    , dockerTools
+    , flyImageTools
     , cacert
     , busybox
-    #, bash
-    #, coreutils
+    , app
     }:
-    dockerTools.buildLayeredImage {
-      name = "${app.name}-container";
-      contents = [
-        # Those are only needed for interactive use (e.g. `docker exec -it ... sh`)
-        # bash
-        # coreutils
-        # or
-        busybox
 
-        # Makes SSL stuff happy
-        cacert
-
-        # Makes the app's binstubs directly available in PATH
-        # Transitively also makes it present at the root of the image.
-        app
+    flyImageTools.buildSpecifiedLayers {
+      layeredContent = [
+        { contents = [ busybox cacert ]; }
+        { contents = [ app.ruby ]; }
+        { contents = [ app.wrappedRuby ]; }
+        {
+          contents = [ app ];
+          config = {
+            # Directly reference the store path means this command works even if the
+            # application isn't added to the contents.
+            Cmd = [ "${app}/bin/rails" "server" ];
+            # This would work too since we're importing `app` as a layer content.
+            # Cmd = [ "rails" "server" ];
+          };
+          extraCommands = lib.optionalString (runtimeDirectory != null) ''
+            mkdir -p ./${runtimeDirectory}/tmp
+          '';
+        }
       ];
-      config = {
-        # Directly reference the store path means this command works even if the
-        # application isn't added to the contents.
-        Cmd = [ "${app}/bin/rails" "server" ];
-        # This would work too since we're importing `app` as a layer content.
-        # Cmd = [ "rails" "server" ];
-      };
-      extraCommands = lib.optionalString (runtimeDirectory != null) ''
-        mkdir -p ./${runtimeDirectory}/tmp
-      '';
     }
-
-  ) {};
+  ) {
+    inherit app flyImageTools;
+  };
 in
   {
     inherit

--- a/image-tools.nix
+++ b/image-tools.nix
@@ -1,0 +1,86 @@
+{ lib, closureInfo, dockerTools }:
+
+let
+  inherit (lib)
+    foldl
+  ;
+in
+{
+  buildSpecifiedLayers =
+    { layeredContent
+    # An image to start building from. Note that store path deduplication will
+    # not be attempted when starting from an existing image.
+    , fromImage ? null
+    }:
+    (
+      foldl (prev:
+        # Name of the layer.
+        { name ? "layer"
+        # Derivations to directly include in the layer.
+        # The content of the store path of these derivations (and not their
+        # dependencies) will be linked at the root of the image.
+        , contents ? []
+        # Commands to run in the context of the layer build.
+        # The result will not be copied in the Nix store, meaning access rights
+        # and other properties stripped by the Nix store are kept.
+        , extraCommands ? ""
+        # Any extra given to `buildLayeredImage`.
+        , ...
+        }@layerConfig:
+        let
+          # Increases the layer count.
+          maxLayers = prev.maxLayers + 1;
+          layer = {
+            layerNumber = prev.layerNumber + 1;
+            inherit maxLayers;
+            contents = prev.contents ++ contents;
+            currentStorePaths = "${closureInfo { rootPaths = contents; }}/store-paths";
+            previousStorePaths = "${closureInfo { rootPaths = prev.contents; }}/store-paths";
+
+            image = dockerTools.buildLayeredImage (layerConfig // {
+              inherit name;
+              # Layer on top of the previous step.
+              fromImage = prev.image;
+              # We're consuming only one layer per step, but `buildLayeredImage`
+              # assumes there is at least one layer for store paths, and one
+              # customization layer.
+              maxLayers = maxLayers + 1;
+              # Skip the built-in implementation of the copy operation.
+              includeStorePaths = false;
+              # Since we're skipping the built-in implementation, let's add our store paths:
+              extraCommands = ''
+                paths() {
+                  # Given:
+                  #   - currentStorePaths = [ c d e f ]
+                  #   - previousStorePaths = [ a b c e ]
+                  # This returns [ d f ]
+                  # `uniq -u` keeps only unique path entries, and we're duplicating unwanted inputs.
+                  sort \
+                    "${layer.currentStorePaths}" \
+                    "${layer.previousStorePaths}" \
+                    "${layer.previousStorePaths}" \
+                    | uniq -u
+                }
+
+                echo ":: Building layer #${toString layer.layerNumber}"
+
+                mkdir -p ./"$NIX_STORE"
+                paths | while read path; do
+                  echo " → Copying '$path' in layer"
+                  cp -prf "$path" "./$path"
+                done
+
+                ${extraCommands}
+              '';
+            });
+          };
+        in
+        layer
+      )
+      { contents = []; layerNumber = 0; maxLayers = 1; image = fromImage; }
+      layeredContent
+    )
+    # Export the build artifact (image) from the last step.
+    .image
+  ;
+}


### PR DESCRIPTION
This stops using the automatic layered approach, instead relying on declaring layers explicitly.

Layers will only include the 𝚫 delta compared to all previous layers.

> **Joshua** Cool. One thing I noticed is that having tons of layers also affects perf, because containerd (docker-like daemon) has to check all of those layers on every deploy

This should help as there is as many layers as declared.

Though this means that care must be taken to optimize sharing between layers. The ordering will matter. This matters if layers are "shared" between customers.

```
┃ ● Layers ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ │
Cmp   Size  Command                                        ├
     34 MB  FROM 1fb5c5a6c7a97cf                           │
     31 MB                                                 │
     52 MB                                                 │
    1.6 MB                                                 │
                                                           │
│ Image Details ├───────────────────────────────────────── │
                                                           │
Image name: layer:kgzpyry823fyqcb9gb79fndx0kg9mz6r         │
Total Image size: 119 MB                                   │
Potential wasted space: 0 B                                │
Image efficiency score: 100 %                              │
                                                           │
```

#### Drawbacks

 - Layers are less likely to be shared between unrelated apps
 - One image per strict layer in the store path

#### Benefits

 - Nix won't rebuild the layers that haven't changed since there's one store path per strict layer.

* * *

Implements #7, solves #9.