### PR TITLE
default.nix: Only used specified gem groups

### DIFF
--- a/wip-docs/02.bundler-groups.md
+++ b/wip-docs/02.bundler-groups.md
@@ -1,0 +1,120 @@
+### How are groups controlled in bundler?
+
+Generally speaking, the assumption is that there will be stateful data local to
+the project by using `bundle install --without test` (and similar) invocations.
+
+It works fine in a stateful world like pretty much any deployments using the
+classic package management strategies.
+
+This is saved in the local configuration with the `with` and `without` entries.
+
+> `without`  
+> A space-separated list of groups referencing gems to skip during installation.
+>
+> `with`  
+> A space-separated list of groups referencing gems to include during installation.
+
+— [`bundle-config(1)`](https://bundler.io/man/bundle-config.1.html)
+
+While this is saved as `.bundle/config` this way, any options can also be
+defined through the environment by capitalizing it and prefixing with `BUNDLE_`.
+Thus, `BUNDLE_WITH` and `BUNDLE_WITHOUT` would be equivalent.
+
+Any gem groups can be skipped by executing with `BUNDLE_WITHOUT=group:list:here`.
+
+The description from the configuration manpage is somewhat misleading. The
+`with` configuration is lacking precision in its behaviour. It is a valid
+interpretation that using `BUNDLE_WITH=development` would strictly use the
+`development` group.
+
+It does not.
+
+This is the implementation bundler uses for groups:
+
+  - https://github.com/rubygems/rubygems/blob/427c047e701eabd164f2ce8195feb4ae6f2c802d/bundler/lib/bundler/definition.rb#L798-L800
+  - https://github.com/rubygems/rubygems/blob/427c047e701eabd164f2ce8195feb4ae6f2c802d/bundler/lib/bundler/definition.rb#L279-L281
+
+The actual behaviour is that **all** non-optional groups are used, except those
+listed in `without`, and augmented with any optional groups in `with`.
+
+With some re-ordering, here's a pseudo-code explanation of the groups used by
+a bundler invocation:
+
+```
+  NON_OPTIONAL ← ALL_GROUPS - OPTIONAL_GROUPS
+  REQUESTED_GROUPS ← NON_OPTIONAL - WITHOUT + WITH
+```
+
+
+### The poor workaround
+
+It would be possible to work around the issue by using the `BUNDLE_WITHOUT`
+environment variable and including all groups that are non-optional and
+unwanted.
+
+This option, though, would require adding an additional indirection layer with
+wrappers. This may look like a passable solution, but relying on the environment
+and additional wrappers is brittle. Anything looking at `$0` or `$PROGRAM_NAME`
+could refer to the wrong thing and end-up bypassing wrappers.
+
+
+### The robust workaround
+
+Since optional groups are removed from non-optional groups, we can attain the
+desired results by editing the Gemfile during the build, and appending
+`group` blocks with `optional: true`.
+
+With this, no environment manipulation is needed, no executable wrappers are
+added in the mix. The only difference is there is an added step during build
+that appends "configuration-like" lines in the Gemfile.
+
+In the end, it's basically like adding this to the end of your file:
+
+```diff
++
++group :test, optional: true do end
++group :development, optional: true do end
+```
+
+This was achievable since `gemset.nix` includes the group information for all
+groups. From there the lists can be `unique`'d and the set subtraction
+`OPTIONAL_GROUPS = ALL_GROUPS - REQUESTED_GROUPS` gives us the groups to ignore.
+
+
+### Other ways forward
+
+As alternatives, or really as proper fixes, there are at least two things that
+could be done.
+
+
+#### Implement *requested groups* in Nixpkgs bundlerEnv
+
+This approach is likely desirable to contribute back upstream. Though we can
+forego the Gemfile modifications, and instead rely on the *existing* wrappers
+where `BUNDLE_*` is configured.
+
+ - https://github.com/NixOS/nixpkgs/blob/4c6f337c48eb06c3cded4652bf1445241901d828/pkgs/development/ruby-modules/bundled-common/gen-bin-stubs.rb
+
+It's okay to be done in *these* wrappers, as they do not rely on `exec` calls
+to work, but instead `load` the gems.
+
+The basic implementation would be the same, but instead of adding
+"configuration-like" lines in the Gemfile, the groups would be added to
+`BUNDLE_WITHOUT`.
+
+
+#### Implement *requested groups* in Bundler
+
+This would be the best way forward with regards to contributing back upstream.
+Though it would also require a lot more work to do correctly and completely.
+
+The basic idea would be to add a `requested_groups` setting, which when present
+is used directly for `#requsted_groups`
+
+  - https://github.com/rubygems/rubygems/blob/427c047e701eabd164f2ce8195feb4ae6f2c802d/bundler/lib/bundler/definition.rb#L798-L800
+
+This would be helpful for any non-stateful systems where only a part of the
+gem groups are installed, not only for Nix and Nix-like systems.
+
+Within Nixpkgs we would then be able to use `BUNDLE_REQUESTED_GROUPS=default`
+to correctly handle the problem.


### PR DESCRIPTION
By default it's only the `default` group.

> ### Only specified groups
>
> ```
> ┃ ● Layers ┣━━━━━━━━━━━━━━━━━━━━━
> Cmp   Size  Command
>      34 MB  FROM 1fb5c5a6c7a97cf
>      31 MB
>      49 MB  ←
>     1.6 MB
> ```
>
> ### All groups
>
> ```
> ┃ ● Layers ┣━━━━━━━━━━━━━━━━━━━━━
> Cmp   Size  Command
>      34 MB  FROM 1fb5c5a6c7a97cf
>      31 MB
>      52 MB  ←
>     1.6 MB
> ```

With upcoming changes for #16, proper care will be taken such that `nix-shell` has the correct environment for development (e.g. *all*).

* * *

Background
=========

Read the [additional notes here](https://github.com/fly-apps/rails-nix/blob/1d024edca56dee5b956d6e26a5856f62e738762a/wip-docs/02.bundler-groups.md).