### PR TITLE
Accept `fly-base` as input to Nix expressions

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,6 @@
-# TODO: link to evalSpec docs and document this module's options
-((import ./fly-base.nix {}).fly.evalSpec) {
+{ fly-base ? (import ./fly-base.nix {})
+}:
+(fly-base.fly.evalSpec) {
   config = {
     templates.rails.enable = true;
     app.source = builtins.fetchGit ./.;

--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,2 @@
-(import ./.).eval.config.outputs.shell
+{ fly-base ? (import ./fly-base.nix {}) }:
+(import ./. { inherit fly-base; }).eval.config.outputs.shell


### PR DESCRIPTION
This allows overriding the package set used as input, useful for
development purposes.

For https://github.com/fly-apps/nix-base/issues/9.